### PR TITLE
Test enhancement

### DIFF
--- a/tests/ServerRequestFactoryTest.php
+++ b/tests/ServerRequestFactoryTest.php
@@ -121,76 +121,143 @@ class ServerRequestFactoryTest extends TestCase
 		$this->assertEquals($files['bar']['type'][0], $uploadedFiles['bar'][0]->getClientMediaType());
 	}
 
-	public function testHeadersFromGlobals()
+	public function headersFromGlobalsProvider()
 	{
-		$request = ServerRequestFactory::fromGlobals(['FOO' => 'bar']);
-		$this->assertEquals([], $request->getHeader('foo'));
-
-		$request = ServerRequestFactory::fromGlobals(['HTTP_FOO' => 'bar']);
-		$this->assertEquals(['bar'], $request->getHeader('foo'));
+		return [
+			[
+				['FOO' => 'bar'],
+				[],
+			],
+			[
+				['HTTP_FOO' => 'bar'],
+				['bar'],
+			],
+		];
 	}
 
-	public function testProtocolVersionFromGlobals()
+	/**
+	 * @dataProvider headersFromGlobalsProvider
+	 */
+	public function testHeadersFromGlobals($header, $expectedValue)
 	{
-		$request = ServerRequestFactory::fromGlobals(['SERVER_PROTOCOL' => 'HTTP/2.0']);
-		$this->assertEquals('2.0', $request->getProtocolVersion());
-
-		$request = ServerRequestFactory::fromGlobals(['SERVER_PROTOCOL' => 'HTTP/3']);
-		$this->assertEquals('3', $request->getProtocolVersion());
+		$request = ServerRequestFactory::fromGlobals($header);
+		$this->assertEquals($expectedValue, $request->getHeader('foo'));
 	}
 
-	public function testMethodFromGlobals()
+	public function protocolVersionFromGlobalsProvider()
 	{
-		$request = ServerRequestFactory::fromGlobals(['REQUEST_METHOD' => 'POST']);
-		$this->assertEquals('POST', $request->getMethod());
-
-		$request = ServerRequestFactory::fromGlobals(['REQUEST_METHOD' => 'UNKNOWN']);
-		$this->assertEquals('UNKNOWN', $request->getMethod());
+		return [
+			[
+				['SERVER_PROTOCOL' => 'HTTP/2.0'],
+				'2.0',
+			],
+			[
+				['SERVER_PROTOCOL' => 'HTTP/3'],
+				'3',
+			],
+		];
 	}
 
-	public function testUriFromGlobals()
+	/**
+	 * @dataProvider protocolVersionFromGlobalsProvider
+	 */
+	public function testProtocolVersionFromGlobals($protocolVersion, $expectedValue)
 	{
-		$request = ServerRequestFactory::fromGlobals([]);
-		$this->assertEquals('http://localhost/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['HTTPS' => 'off']);
-		$this->assertEquals('http://localhost/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['HTTPS' => 'on']);
-		$this->assertEquals('https://localhost/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['HTTP_HOST' => 'example.com']);
-		$this->assertEquals('http://example.com/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['HTTP_HOST' => 'example.com:3000']);
-		$this->assertEquals('http://example.com:3000/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['SERVER_NAME' => 'example.com']);
-		$this->assertEquals('http://example.com/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['SERVER_NAME' => 'example.com', 'SERVER_PORT' => 3000]);
-		$this->assertEquals('http://example.com:3000/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['SERVER_PORT' => 3000]);
-		$this->assertEquals('http://localhost/', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/path']);
-		$this->assertEquals('http://localhost/path', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['REQUEST_URI' => '/path?query']);
-		$this->assertEquals('http://localhost/path?query', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['PHP_SELF' => '/path']);
-		$this->assertEquals('http://localhost/path', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['PHP_SELF' => '/path', 'QUERY_STRING' => 'query']);
-		$this->assertEquals('http://localhost/path?query', (string) $request->getUri());
-
-		$request = ServerRequestFactory::fromGlobals(['QUERY_STRING' => 'query']);
-		$this->assertEquals('http://localhost/', (string) $request->getUri());
+		$request = ServerRequestFactory::fromGlobals($protocolVersion);
+		$this->assertEquals($expectedValue, $request->getProtocolVersion());
 	}
 
-	public function tearDown()
+	public function methodFromGlobalsProvider()
+	{
+		return [
+			[
+				['REQUEST_METHOD' => 'POST'],
+				'POST',
+			],
+			[
+				['REQUEST_METHOD' => 'UNKNOWN'],
+				'UNKNOWN',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider methodFromGlobalsProvider
+	 */
+	public function testMethodFromGlobals($requestMethod, $expectedValue)
+	{
+		$request = ServerRequestFactory::fromGlobals($requestMethod);
+		$this->assertEquals($expectedValue, $request->getMethod());
+	}
+
+	public function uriFromGlobalsProvider()
+	{
+		return [
+			[
+				[],
+				'http://localhost/',
+			],
+			[
+				['HTTPS' => 'off'],
+				'http://localhost/',
+			],
+			[
+				['HTTPS' => 'on'],
+				'https://localhost/',
+			],
+			[
+				['HTTP_HOST' => 'example.com'],
+				'http://example.com/',
+			],
+			[
+				['HTTP_HOST' => 'example.com:3000'],
+				'http://example.com:3000/',
+			],
+			[
+				['SERVER_NAME' => 'example.com'],
+				'http://example.com/',
+			],
+			[
+				['SERVER_NAME' => 'example.com', 'SERVER_PORT' => 3000],
+				'http://example.com:3000/',
+			],
+			[
+				['SERVER_PORT' => 3000],
+				'http://localhost/',
+			],
+			[
+				['REQUEST_URI' => '/path'],
+				'http://localhost/path',
+			],
+			[
+				['REQUEST_URI' => '/path?query'],
+				'http://localhost/path?query',
+			],
+			[
+				['PHP_SELF' => '/path'],
+				'http://localhost/path',
+			],
+			[
+				['PHP_SELF' => '/path', 'QUERY_STRING' => 'query'],
+				'http://localhost/path?query',
+			],
+			[
+				['QUERY_STRING' => 'query'],
+				'http://localhost/',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider uriFromGlobalsProvider
+	 */
+	public function testUriFromGlobals($uri, $expectedValue)
+	{
+		$request = ServerRequestFactory::fromGlobals($uri);
+		$this->assertEquals($expectedValue, (string) $request->getUri());
+	}
+
+	protected function tearDown()
 	{
 		$tmpfiles = $this->tmpfiles;
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -94,11 +94,11 @@ class ServerRequestTest extends TestCase
 	public function testParsedBody($parsedBody)
 	{
 		$req = new ServerRequest();
-		$this->assertEquals(null, $req->getParsedBody());
+		$this->assertNull($req->getParsedBody());
 
 		$clone = $req->withParsedBody($parsedBody);
 		$this->assertInstanceOf(ServerRequestInterface::class, $clone);
-		$this->assertEquals(null, $req->getParsedBody());
+		$this->assertNull($req->getParsedBody());
 		$this->assertEquals($parsedBody, $clone->getParsedBody());
 	}
 
@@ -124,8 +124,8 @@ class ServerRequestTest extends TestCase
 
 		$this->assertEquals('bar', $req->getAttribute('foo'));
 		$this->assertEquals('baz', $req->getAttribute('bar'));
-		$this->assertEquals(null, $req->getAttribute('baz'));
-		$this->assertEquals(false, $req->getAttribute('baz', false));
+		$this->assertNull($req->getAttribute('baz'));
+		$this->assertFalse($req->getAttribute('baz', false));
 	}
 
 	public function testDeleteAttribute()
@@ -137,12 +137,12 @@ class ServerRequestTest extends TestCase
 		$clone1 = $req->withoutAttribute('foo');
 		$this->assertInstanceOf(ServerRequestInterface::class, $clone1);
 		$this->assertEquals(['bar' => 'baz'], $clone1->getAttributes());
-		$this->assertEquals(null, $clone1->getAttribute('foo'));
+		$this->assertNull($clone1->getAttribute('foo'));
 
 		$clone2 = $clone1->withoutAttribute('bar');
 		$this->assertInstanceOf(ServerRequestInterface::class, $clone2);
 		$this->assertEquals([], $clone2->getAttributes());
-		$this->assertEquals(null, $clone2->getAttribute('bar'));
+		$this->assertNull($clone2->getAttribute('bar'));
 	}
 
 	// Providers...

--- a/tests/UploadedFileFactoryTest.php
+++ b/tests/UploadedFileFactoryTest.php
@@ -43,8 +43,8 @@ class UploadedFileFactoryTest extends TestCase
 		$this->assertEquals($this->stream, $uploadedFile->getStream());
 		$this->assertEquals($this->stream->getSize(), $uploadedFile->getSize());
 		$this->assertEquals(\UPLOAD_ERR_OK, $uploadedFile->getError());
-		$this->assertEquals(null, $uploadedFile->getClientFilename());
-		$this->assertEquals(null, $uploadedFile->getClientMediaType());
+		$this->assertNull($uploadedFile->getClientFilename());
+		$this->assertNull($uploadedFile->getClientMediaType());
 	}
 
 	public function testCreateUploadedFileWithParameters()

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -14,14 +14,14 @@ class UploadedFileTest extends TestCase
 
 	private $targetPath = '';
 
-	public function setUp()
+	protected function setUp()
 	{
 		$this->stream = (new StreamFactory)->createStreamFromFile('php://memory', 'r+b');
 
 		$this->targetPath = \sys_get_temp_dir() . '/' . \bin2hex(\random_bytes(16));
 	}
 
-	public function tearDown()
+	protected function tearDown()
 	{
 		if ($this->stream instanceof StreamInterface)
 		{
@@ -102,14 +102,14 @@ class UploadedFileTest extends TestCase
 	{
 		$uploadedFile = new UploadedFile($this->stream);
 
-		$this->assertEquals(null, $uploadedFile->getClientFilename());
+		$this->assertNull($uploadedFile->getClientFilename());
 	}
 
 	public function testGetDefaultClientMediaType()
 	{
 		$uploadedFile = new UploadedFile($this->stream);
 
-		$this->assertEquals(null, $uploadedFile->getClientMediaType());
+		$this->assertNull($uploadedFile->getClientMediaType());
 	}
 
 	public function testMoveTo()
@@ -120,7 +120,7 @@ class UploadedFileTest extends TestCase
 		$uploadedFile = new UploadedFile($this->stream);
 		$uploadedFile->moveTo($this->targetPath);
 
-		$this->assertTrue(\file_exists($this->targetPath));
+		$this->assertFileExists($this->targetPath);
 		$this->assertEquals($content, \file_get_contents($this->targetPath));
 	}
 


### PR DESCRIPTION
# Changed log
- Using the `assertNull` to assert whether the expected value is same as null.
- Using the `assertFileExists` to assert whether the specific file is existed.
- Using the data provider to split test cases from the method.
- Using the `protected` instead of `public` for `setUp` and `tearDown` methods.
It can find the details on [official PHPUnit doc](https://phpunit.readthedocs.io/en/7.4/fixtures.html?highlight=setUp).