### PR TITLE
Test enhancement

### DIFF
--- a/tests/UploadedFileFactoryTest.php
+++ b/tests/UploadedFileFactoryTest.php
@@ -13,14 +13,14 @@ class UploadedFileFactoryTest extends TestCase
 {
 	private $stream;
 
-	public function setUp()
+	protected function setUp()
 	{
 		$this->stream = (new StreamFactory)->createStreamFromFile('php://memory', 'r+b');
 
 		$this->stream->write('foo');
 	}
 
-	public function tearDown()
+	protected function tearDown()
 	{
 		if ($this->stream instanceof StreamInterface)
 		{


### PR DESCRIPTION
The `TestCase::setUp` and `TestCase::tearDown` should be `protected` methods, not `public`.